### PR TITLE
Update data-load macro

### DIFF
--- a/STAT6250-02_s17-team-0_project2_data_preparation.sas
+++ b/STAT6250-02_s17-team-0_project2_data_preparation.sas
@@ -98,7 +98,7 @@ https://github.com/stat6250/team-0_project2/blob/master/data/sat15-edited.xls?ra
     %then
         %do;
             %put Loading dataset &dsn. over the wire now...;
-            filename tempfile TEMP;
+            filename tempfile "%sysfunc(getoption(work))/tempfile.xlsx";
             proc http
                 method="get"
                 url="&url."


### PR DESCRIPTION
Switch from a SAS-managed temp file to a temp-file explicitly stored in
the same location as the Work library, mitigating issues apparently
caused by some malformed .xlsx files